### PR TITLE
Fix some failed searches caused by the search query not being escaped.

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -91,7 +91,7 @@ defmodule Algolia do
   Search a single index
   """
   def search(index, query, opts) do
-    path = "#{index}?query=#{query}" <> opts_to_query_params(opts)
+    path = "#{index}?query=#{URI.encode query}" <> opts_to_query_params(opts)
     send_request(:read, :get, path)
   end
   def search(index, query), do: search(index, query, [])


### PR DESCRIPTION
Had quite a few errors (invalid request) returned from searches, traced it back to this.
