### PR TITLE
support search opts with list values

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -87,7 +87,12 @@ defmodule Algolia do
   Search a single index
   """
   def search(index, query, opts \\ []) do
-    opts = Keyword.put(opts, :query, query)
+    opts = opts
+      |> Keyword.put(:query, query)
+      |> Enum.map(fn {k,v} ->
+          v = if is_list(v), do: Enum.join(v, ","), else: v
+          {k, v}
+        end)
     path = index <> "?" <> URI.encode_query(opts)
     send_request(:read, :get, path)
   end

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -82,6 +82,23 @@ defmodule AlgoliaTest do
     assert length(hits1) === count
   end
 
+  test "search with list opts" do
+    :rand.seed(:exs1024, :erlang.timestamp)
+    count = :rand.uniform 10
+    docs = Enum.map(1..count, &(%{id: &1, test: "search with list opts"}))
+
+    {:ok, _} = save_objects("test_3", docs, id_attribute: :id) |> wait
+
+    opts = [
+      responseFields: ["hits", "nbPages"]
+    ]
+    {:ok, response} = search("test_3", "search_with_list_opts", opts)
+
+    assert response["hits"]
+    assert response["nbPages"]
+    refute response["page"]
+  end
+
   test "search > 1 pages" do
     docs = Enum.map(1..40, &(%{id: &1, test: "search_more_than_one_pages"}))
 


### PR DESCRIPTION
There's a few options in Algolia that has array values such as [facets](https://www.algolia.com/doc/api-reference/api-parameters/facets/) and [attributesToRetrieve](https://www.algolia.com/doc/api-reference/api-parameters/attributesToRetrieve/). This was supported in 0.6.1 but I believe this commit https://github.com/sikanhe/algolia-elixir/commit/a7209b6511a794f2bfe93db1c15d2b2743e9f6f2 caused it to no longer work.

This PR includes a failing test demonstrating the issue and a fix that passes the new test and all existing tests.