### PR TITLE
Allow extra HTTP headers to be passed along the search query

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -85,7 +85,7 @@ defmodule Algolia do
   @doc """
   Search a single index
   """
-  def search(index, query, opts \\ []) do
+  def search(index, query, opts \\ [], request_options \\ []) do
     opts =
       opts
       |> Keyword.put(:query, query)
@@ -95,7 +95,7 @@ defmodule Algolia do
       end)
 
     path = index <> "?" <> URI.encode_query(opts)
-    send_request(:read, %{method: :get, path: path})
+    send_request(:read, %{method: :get, path: path, options: request_options})
   end
 
   @doc """
@@ -171,9 +171,11 @@ defmodule Algolia do
       |> Path.join("/1/indexes")
       |> Path.join(request[:path])
 
-    headers = [
-      "X-Algolia-API-Key": api_key(),
-      "X-Algolia-Application-Id": application_id()
+    extra_headers = get_in(request, [:options, :headers]) || []
+
+    headers = extra_headers ++ [
+      {"X-Algolia-API-Key", api_key()},
+      {"X-Algolia-Application-Id", application_id()}
     ]
 
     body = request[:body] || ""


### PR DESCRIPTION
This feature is supported by the official Algolia clients and it permits, for example, to track the original user IP address for analytics or geo purposes.

https://www.algolia.com/doc/api-reference/api-methods/set-extra-header/

Now we can inject headers like this:

```elixir
Algolia.search(index, "query", [hitsPerPage: 30], headers: [{"X-Forwaded-For", "1.2.3.4"}])
```

I tried to keep the signature and the implementation similar to the one found in Algolia's own Ruby client:

https://github.com/algolia/algoliasearch-client-ruby/blob/046edc353c7b399edbb280601ef24555129e8dc1/lib/algolia/index.rb#L161

https://github.com/algolia/algoliasearch-client-ruby/blob/046edc353c7b399edbb280601ef24555129e8dc1/lib/algolia/client.rb#L556-L560