### PR TITLE
Refactor send_request for extensibility

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -59,7 +59,7 @@ defmodule Algolia do
     path = "*/queries" <> params
     body = queries |> format_multi() |> Jason.encode!()
 
-    send_request(:read, :post, path, body)
+    send_request(:read, %{method: :post, path: path, body: body})
   end
 
   defp format_multi(queries) do
@@ -95,7 +95,7 @@ defmodule Algolia do
       end)
 
     path = index <> "?" <> URI.encode_query(opts)
-    send_request(:read, :get, path)
+    send_request(:read, %{method: :get, path: path})
   end
 
   @doc """
@@ -155,34 +155,30 @@ defmodule Algolia do
       |> Map.put("facetQuery", text)
       |> Jason.encode!()
 
-    send_request(:read, :post, path, body)
+    send_request(:read, %{method: :post, path: path, body: body})
   end
 
-  defp send_request(read_or_write, method, path) do
-    send_request(read_or_write, method, path, "", 0)
-  end
+  defp send_request(read_or_write, request, curr_retry \\ 0)
 
-  defp send_request(read_or_write, method, path, body) do
-    send_request(read_or_write, method, path, body, 0)
-  end
-
-  defp send_request(_, _, _, _, 4) do
+  defp send_request(_read_or_write, _request, 4) do
     {:error, "Unable to connect to Algolia"}
   end
 
-  defp send_request(read_or_write, method, path, body, curr_retry) do
+  defp send_request(read_or_write, request, curr_retry) do
     url =
       "https://"
       |> Path.join(host(read_or_write, curr_retry))
       |> Path.join("/1/indexes")
-      |> Path.join(path)
+      |> Path.join(request[:path])
 
     headers = [
       "X-Algolia-API-Key": api_key(),
       "X-Algolia-Application-Id": application_id()
     ]
 
-    method
+    body = request[:body] || ""
+
+    request[:method]
     |> :hackney.request(url, headers, body, [
       :with_body,
       path_encode_fun: &URI.encode/1,
@@ -191,14 +187,14 @@ defmodule Algolia do
       ssl_options: [{:versions, [:"tlsv1.2"]}]
     ])
     |> case do
-      {:ok, code, _headers, body} when code in 200..299 ->
-        {:ok, Jason.decode!(body)}
+      {:ok, code, _headers, response} when code in 200..299 ->
+        {:ok, Jason.decode!(response)}
 
-      {:ok, code, _, body} ->
-        {:error, code, body}
+      {:ok, code, _, response} ->
+        {:error, code, response}
 
       _ ->
-        send_request(read_or_write, method, path, body, curr_retry + 1)
+        send_request(read_or_write, request, curr_retry + 1)
     end
   end
 
@@ -209,7 +205,7 @@ defmodule Algolia do
     path = "#{index}/#{object_id}"
 
     :read
-    |> send_request(:get, path)
+    |> send_request(%{method: :get, path: path})
     |> inject_index_into_response(index)
   end
 
@@ -221,7 +217,7 @@ defmodule Algolia do
     path = "#{index}"
 
     :write
-    |> send_request(:post, path, body)
+    |> send_request(%{method: :post, path: path, body: body})
     |> inject_index_into_response(index)
   end
 
@@ -268,7 +264,7 @@ defmodule Algolia do
     path = "#{index}/#{object_id}"
 
     :write
-    |> send_request(:put, path, body)
+    |> send_request(%{method: :put, path: path, body: body})
     |> inject_index_into_response(index)
   end
 
@@ -284,7 +280,7 @@ defmodule Algolia do
     path = "#{index}/#{object_id}"
 
     :write
-    |> send_request(:put, path, body)
+    |> send_request(%{method: :put, path: path, body: body})
     |> inject_index_into_response(index)
   end
 
@@ -320,7 +316,7 @@ defmodule Algolia do
     path = "#{index}/#{object_id}/partial" <> URI.encode(params)
 
     :write
-    |> send_request(:post, path, body)
+    |> send_request(%{method: :post, path: path, body: body})
     |> inject_index_into_response(index)
   end
 
@@ -376,7 +372,7 @@ defmodule Algolia do
     body = Jason.encode!(requests)
 
     :write
-    |> send_request(:post, path, body)
+    |> send_request(%{method: :post, path: path, body: body})
     |> inject_index_into_response(index)
   end
 
@@ -403,7 +399,7 @@ defmodule Algolia do
     path = "#{index}/#{object_id}"
 
     :write
-    |> send_request(:delete, path)
+    |> send_request(%{method: :delete, path: path})
     |> inject_index_into_response(index)
   end
 
@@ -423,7 +419,7 @@ defmodule Algolia do
   List all indexes
   """
   def list_indexes do
-    send_request(:read, :get, "")
+    send_request(:read, %{method: :get, path: ""})
   end
 
   @doc """
@@ -433,7 +429,7 @@ defmodule Algolia do
     path = "#{index}"
 
     :write
-    |> send_request(:delete, path)
+    |> send_request(%{method: :delete, path: path})
     |> inject_index_into_response(index)
   end
 
@@ -444,7 +440,7 @@ defmodule Algolia do
     path = "#{index}/clear"
 
     :write
-    |> send_request(:post, path)
+    |> send_request(%{method: :post, path: path})
     |> inject_index_into_response(index)
   end
 
@@ -455,7 +451,7 @@ defmodule Algolia do
     body = Jason.encode!(settings)
 
     :write
-    |> send_request(:put, "/#{index}/settings", body)
+    |> send_request(%{method: :put, path: "/#{index}/settings", body: body})
     |> inject_index_into_response(index)
   end
 
@@ -464,7 +460,7 @@ defmodule Algolia do
   """
   def get_settings(index) do
     :read
-    |> send_request(:get, "/#{index}/settings")
+    |> send_request(%{method: :get, path: "/#{index}/settings"})
     |> inject_index_into_response(index)
   end
 
@@ -475,7 +471,7 @@ defmodule Algolia do
     body = Jason.encode!(%{operation: "move", destination: dst_index})
 
     :write
-    |> send_request(:post, "/#{src_index}/operation", body)
+    |> send_request(%{method: :post, path: "/#{src_index}/operation", body: body})
     |> inject_index_into_response(src_index)
   end
 
@@ -486,7 +482,7 @@ defmodule Algolia do
     body = Jason.encode!(%{operation: "copy", destination: dst_index})
 
     :write
-    |> send_request(:post, "/#{src_index}/operation", body)
+    |> send_request(%{method: :post, path: "/#{src_index}/operation", body: body})
     |> inject_index_into_response(src_index)
   end
 
@@ -502,7 +498,7 @@ defmodule Algolia do
   returns :ok when it's done
   """
   def wait_task(index, task_id, time_before_retry \\ 1000) do
-    case send_request(:write, :get, "#{index}/task/#{task_id}") do
+    case send_request(:write, %{method: :get, path: "#{index}/task/#{task_id}"}) do
       {:ok, %{"status" => "published"}} ->
         :ok
 

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -165,17 +165,8 @@ defmodule Algolia do
   end
 
   defp send_request(read_or_write, request, curr_retry) do
-    url =
-      "https://"
-      |> Path.join(host(read_or_write, curr_retry))
-      |> Path.join("/1/indexes")
-      |> Path.join(request[:path])
-
-    headers = [
-      "X-Algolia-API-Key": api_key(),
-      "X-Algolia-Application-Id": application_id()
-    ]
-
+    url = request_url(read_or_write, curr_retry, request[:path])
+    headers = request_headers()
     body = request[:body] || ""
 
     request[:method]
@@ -196,6 +187,20 @@ defmodule Algolia do
       _ ->
         send_request(read_or_write, request, curr_retry + 1)
     end
+  end
+
+  defp request_url(read_or_write, retry, path) do
+    "https://"
+    |> Path.join(host(read_or_write, retry))
+    |> Path.join("/1/indexes")
+    |> Path.join(path)
+  end
+
+  defp request_headers() do
+    [
+      "X-Algolia-API-Key": api_key(),
+      "X-Algolia-Application-Id": application_id()
+    ]
   end
 
   @doc """


### PR DESCRIPTION
Extracted from #20.

Replacing 3 request-related parameters – namely `method`, `path` and `body` – with a map, we make room for extensions, such as adding a new request-related field, without further deeper changes to the arity or the signature of `send_request`. Turning them into a map will also provide better control over the handling of default values.

Also extracting URL and request headers building logic into their own functions.