### PR TITLE
Allow extra HTTP headers to be passed along Algolia requests

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -271,7 +271,7 @@ defmodule Algolia do
     if id_attribute = opts[:id_attribute] do
       object[id_attribute] || object[to_string(id_attribute)] ||
         raise ArgumentError,
-          message: "Your object #{object} does not have a '#{id_attribute}' attribute"
+          message: "Your object does not have a '#{id_attribute}' attribute"
     else
       object["objectID"] || object[:objectID] ||
         raise ArgumentError,

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -71,6 +71,20 @@ defmodule AlgoliaTest do
     assert {:ok, %{"objectID" => ^object_id}} = get_object("test_1", id)
   end
 
+  describe "save_object/2" do
+    test "requires an objectID attribute" do
+      assert_raise ArgumentError, ~r/must have an objectID/, fn ->
+        save_object("test_1", %{"noObjectId" => "raises error"})
+      end
+    end
+
+    test "requires a valid attribute as object id" do
+      assert_raise ArgumentError, ~r/does not have a 'id' attribute/, fn ->
+        save_object("test_1", %{"noId" => "raises error"}, id_attribute: "id")
+      end
+    end
+  end
+
   test "search single index" do
     :rand.seed(:exs1024, :erlang.timestamp)
     count = :rand.uniform 10


### PR DESCRIPTION
Supersedes #20, now adding support for all requests, not only `search`.

This feature is supported by the official Algolia clients and it permits, for example, to track the original user IP address for analytics or geo purposes.

https://www.algolia.com/doc/api-reference/api-methods/set-extra-header/