### PR TITLE
Add delete_by support

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -422,6 +422,46 @@ defmodule Algolia do
   end
 
   @doc """
+  Remove all objects matching a filter (including geo filters).
+
+  ## Examples
+
+      iex> Algolia.delete_by("index", filters: ["score < 30"])
+      {:ok, %{"indexName" => "index", "taskId" => 42, "deletedAt" => "2018-10-30T15:33:13.556Z"}}
+  """
+  def delete_by(index, opts) when is_list(opts) do
+    {request_options, opts} = Keyword.pop(opts, :request_options)
+
+    path = "#{index}/deleteByQuery"
+
+    body =
+      opts
+      |> sanitize_delete_by_opts()
+      |> validate_delete_by_opts!()
+      |> to_query()
+      |> Jason.encode!()
+
+    :write
+    |> send_request(%{method: :post, path: path, body: body, options: request_options})
+    |> inject_index_into_response(index)
+  end
+
+  defp sanitize_delete_by_opts(opts) do
+    Keyword.drop(opts || [], [
+      :hitsPerPage,
+      :attributesToRetrieve,
+      "hitsPerPage",
+      "attributesToRetrieve"
+    ])
+  end
+
+  defp validate_delete_by_opts!([]) do
+    raise ArgumentError, message: "opts are required, use `clear_index/1` to wipe the index."
+  end
+
+  defp validate_delete_by_opts!(opts), do: opts
+
+  @doc """
   List all indexes
   """
   def list_indexes do

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -89,14 +89,18 @@ defmodule Algolia do
     opts =
       opts
       |> Keyword.put(:query, query)
-      |> Enum.map(fn {k, v} ->
-        v = if is_list(v), do: Enum.join(v, ","), else: v
-        {k, v}
-      end)
+      |> to_query()
 
     path = index <> "?" <> URI.encode_query(opts)
     send_request(:read, %{method: :get, path: path, options: request_options})
   end
+
+  defp to_query(enumerable) do
+    Map.new(enumerable, fn {key, value} -> {key, to_param(value)} end)
+  end
+
+  defp to_param(value) when is_list(value), do: Enum.join(value, ",")
+  defp to_param(value), do: value
 
   @doc """
   Search for facet values


### PR DESCRIPTION
With `delete_by/2` we can remove all objects matching a given set of filters.

https://www.algolia.com/doc/api-reference/api-methods/delete-by/
https://www.algolia.com/doc/rest-api/search/#delete-by

Reference implementation from Algolia's Ruby client:

* https://github.com/algolia/algoliasearch-client-ruby/blob/1.23.0/lib/algolia/index.rb#L483-L506
* https://github.com/algolia/algoliasearch-client-ruby/blob/1.23.0/lib/algolia/index.rb#L1138-L1145

### TODO

* [x] Add support for `request_options` if #22 goes out first.