### PR TITLE
Add get_logs

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -399,6 +399,15 @@ defmodule Algolia do
   @doc """
   Remove all objects matching a filter (including geo filters).
 
+  Allowed filter parameters:
+
+  * `filters`
+  * `facetFilters`
+  * `numericFilters`
+  * `aroundLatLng` and `aroundRadius` (these two need to be used together)
+  * `insideBoundingBox`
+  * `insidePolygon`
+
   ## Examples
 
       iex> Algolia.delete_by("index", filters: ["score < 30"])
@@ -510,6 +519,25 @@ defmodule Algolia do
   end
 
   defp inject_index_into_response(response, _index), do: response
+
+  @doc """
+  Get the logs of the latest search and indexing operations.
+
+  ## Options
+
+    * `:indexName` - Index for which log entries should be retrieved. When omitted,
+      log entries are retrieved across all indices.
+
+    * `:length` - Maximum number of entries to retrieve. Maximum allowed value: 1000.
+
+    * `:offset` - First entry to retrieve (zero-based). Log entries are sorted by
+      decreasing date, therefore 0 designates the most recent log entry.
+
+    * `:type` - Type of log to retrieve: `all` (default), `query`, `build` or `error`.
+  """
+  def get_logs(opts \\ []) do
+    send_request(:write, %{method: :get, path: Paths.logs(opts)})
+  end
 
   @doc """
   Wait for a task for an index to complete

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -43,6 +43,11 @@ defmodule Algolia.Paths do
 
   def settings(index), do: index(index) <> "/settings"
 
+  def logs(opts) do
+    params = Keyword.take(opts, [:indexName, :offset, :length, :type])
+    "/#{@version}/logs" <> to_query(params)
+  end
+
   defp to_query([]), do: ""
   defp to_query(params), do: "?" <> build_query(params)
 

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -1,0 +1,59 @@
+defmodule Algolia.Paths do
+  @moduledoc false
+
+  @version 1
+
+  def indexes, do: "/#{@version}/indexes"
+
+  def multiple_queries(strategy) do
+    params = strategy_params(strategy)
+    indexes() <> "/*/queries" <> to_query(params)
+  end
+
+  defp strategy_params(:stop_if_enough_matches), do: [strategy: "stopIfEnoughMatches"]
+  defp strategy_params(_), do: []
+
+  def index(index), do: indexes() <> "/" <> URI.encode(index)
+
+  def batch(index), do: index(index) <> "/batch"
+
+  def operation(index), do: index(index) <> "/operation"
+
+  def task(index, task_id), do: index(index) <> "/task/#{task_id}"
+
+  def object(index, object_id), do: index(index) <> "/#{object_id}"
+
+  def partial_object(index, object_id, upsert) do
+    params = if upsert, do: [], else: [createIfNotExists: false]
+    object(index, object_id) <> "/partial" <> to_query(params)
+  end
+
+  def search(index, query, opts) do
+    params = Keyword.put(opts, :query, query)
+    index(index) <> to_query(params)
+  end
+
+  def search_facet(index, facet) do
+    index(index) <> "/facets/" <> URI.encode(facet) <> "/query"
+  end
+
+  def clear(index), do: index(index) <> "/clear"
+
+  def delete_by(index), do: index(index) <> "/deleteByQuery"
+
+  def settings(index), do: index(index) <> "/settings"
+
+  defp to_query([]), do: ""
+  defp to_query(params), do: "?" <> build_query(params)
+
+  defp build_query(params) do
+    params
+    |> Enum.map(&encode_param/1)
+    |> URI.encode_query()
+  end
+
+  defp encode_param({key, value}), do: {key, encode_value(value)}
+
+  defp encode_value(value) when is_list(value), do: Enum.join(value, ",")
+  defp encode_value(value), do: value
+end

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -350,4 +350,11 @@ defmodule AlgoliaTest do
     all_indexes = Enum.map(items, & &1["name"])
     refute index in all_indexes
   end
+
+  test "get index logs" do
+    {:ok, _} = search("test", "test query")
+
+    assert {:ok, %{"logs" => [log]}} = get_logs(indexName: "test", length: 1, type: :query)
+    assert %{"index" => "test", "query_params" => "query=test+query"} = log
+  end
 end

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -357,4 +357,17 @@ defmodule AlgoliaTest do
     assert {:ok, %{"logs" => [log]}} = get_logs(indexName: "test", length: 1, type: :query)
     assert %{"index" => "test", "query_params" => "query=test+query"} = log
   end
+
+  test "forwards extra HTTP headers" do
+    opts = [headers: [{"X-Forwarded-For", "1.2.3.4"}]]
+
+    {:ok, _} =
+      "test"
+      |> add_object(%{text: "hello"}, request_options: opts)
+      |> wait
+
+    {:ok, %{"logs" => [log]}} = get_logs(indexName: "test", length: 1, type: :build)
+    %{"index" => "test", "query_headers" => headers} = log
+    assert headers =~ ~r/X-Forwarded-For: 1\.2\.3\.4/
+  end
 end


### PR DESCRIPTION
Official docs: https://www.algolia.com/doc/api-reference/api-methods/get-logs/

Since this is an operation that happens outside of the "indexes" scope, a refactor was required to keep `request_url` from prepending `/1/indexes` in teh final URL.

### Sample usage:

```elixir
Algolia.get_logs(type: :error, length: 5)
{:ok, %{"logs" => [..]}}
```