### PR TITLE
[WIP] Add synonyms and query rules support

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -575,18 +575,19 @@ defmodule Algolia do
   @doc """
   Create or update an list of synonyms.
 
-  Allowed params:
-  * `forwardToReplicas`
-  * `replaceExistingSynonyms`
   * `synonyms` Required: With [synonyms objects](https://www.algolia.com/doc/api-reference/api-methods/save-synonym/#method-param-synonym-object).
   * - `objectID` Required: If the Id do not exist it will be created.
   * - `type` Required: Allowed the types: `"synonym,oneWaySynonym,altCorrection1,altCorrection2,placeholder"`.
   * - `synonyms` Required if type=synonym or type=oneWaySynonym: List of strings.
   * - `input` Required if type=oneWaySynonym.
   * - `word` Required if type=altCorrection1 or type=altCorrection2.
-  * - `corrections` Required if type=altCorrection1 or type=altCorrection2
-  * - `placeholder` Required if type=placeholder
-  * - `replacements` Required if type=placeholder
+  * - `corrections` Required if type=altCorrection1 or type=altCorrection2.
+  * - `placeholder` Required if type=placeholder.
+  * - `replacements` Required if type=placeholder.
+
+  Allowed params:
+  * `forwardToReplicas`
+  * `replaceExistingSynonyms`
   """
   def batch_synonyms(index, batch, opts \\ []) do
     body = Jason.encode!(batch)
@@ -630,10 +631,29 @@ defmodule Algolia do
   end
 
   @doc """
-  Create or update an list of synonyms.
+  Create or update an list of Query Rules.
+
+  * `batch` Required: list with [Query Rules](https://www.algolia.com/doc/api-reference/api-methods/save-rule/#method-param-rule)
+  * - `objectID` Required: If the Id do not exist it will be created.
+  * - `description` To ease searching for rules and presenting them to human readers.
+  * - `enabled` Whether the rule is enabled. Disabled rules remain in the index, but are not applied at query time.
+  * - `validity` By default, rules are permanently valid. When validity periods are specified, the rule applies only during those periods.
+  * - `condition` Required: [condition](https://www.algolia.com/doc/api-reference/api-methods/save-rule/?language=javascript#method-param-condition-2)
+  * -- `pattern` Required: Query patterns are expressed as a string with a specific syntax.
+  * -- `anchoring` Required: Enum `["is", "startsWith", "endsWith", "contains"]`.
+  * -- `context`: Rule context. When specified, the rule is contextual and applies only when the same context is specified at query time.
+  * - `consequence` Required at least 1 [consequence](https://www.algolia.com/doc/api-reference/api-methods/save-rule/?language=javascript#method-param-consequence-2)
+  * -- `params`: Additional search parameters. Any valid search parameter is allowed.
+  * -- `promote`: List with objects to promote as hits.
+  * --- `objectID`
+  * --- `position`
+  * -- `hide`: List with objects to hide from hits.
+  * --- `objectID`
+  * -- `userData`: Custom JSON object that will be appended to the userData array in the response.
 
   Allowed params:
-
+  * `forwardToReplicas` When true, the change is forwarded to all replicas of this index.
+  * `clearExistingRules` When true, existing rules are cleared before adding this batch.
   """
   def batch_rules(index, batch, opts \\ []) do
     body = Jason.encode!(batch)

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -586,8 +586,8 @@ defmodule Algolia do
   * - `replacements` Required if type=placeholder.
 
   Allowed params:
-  * `forward_to_replicas`
-  * `replace_existing_synonyms`
+  * `forwardToReplicas`
+  * `replaceExistingSynonyms`
   """
   def batch_synonyms(index, batch, opts \\ []) do
     body = Jason.encode!(batch)
@@ -652,8 +652,8 @@ defmodule Algolia do
   * -- `userData`: Custom JSON object that will be appended to the userData array in the response.
 
   Allowed params:
-  * `forward_to_replicas` When true, the change is forwarded to all replicas of this index.
-  * `clear_existing_rules` When true, existing rules are cleared before adding this batch.
+  * `forwardToReplicas` When true, the change is forwarded to all replicas of this index.
+  * `clearExistingRules` When true, existing rules are cleared before adding this batch.
   """
   def batch_rules(index, batch, opts \\ []) do
     body = Jason.encode!(batch)

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -586,8 +586,8 @@ defmodule Algolia do
   * - `replacements` Required if type=placeholder.
 
   Allowed params:
-  * `forwardToReplicas`
-  * `replaceExistingSynonyms`
+  * `forward_to_replicas`
+  * `replace_existing_synonyms`
   """
   def batch_synonyms(index, batch, opts \\ []) do
     body = Jason.encode!(batch)
@@ -652,8 +652,8 @@ defmodule Algolia do
   * -- `userData`: Custom JSON object that will be appended to the userData array in the response.
 
   Allowed params:
-  * `forwardToReplicas` When true, the change is forwarded to all replicas of this index.
-  * `clearExistingRules` When true, existing rules are cleared before adding this batch.
+  * `forward_to_replicas` When true, the change is forwarded to all replicas of this index.
+  * `clear_existing_rules` When true, existing rules are cleared before adding this batch.
   """
   def batch_rules(index, batch, opts \\ []) do
     body = Jason.encode!(batch)

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -473,9 +473,9 @@ defmodule Algolia do
   @doc """
   Set the settings of a index
   """
-  def set_settings(index, settings) do
+  def set_settings(index, settings, opts \\ []) do
     body = Jason.encode!(settings)
-    path = Paths.settings(index)
+    path = Paths.settings(index, opts)
 
     :write
     |> send_request(%{method: :put, path: path, body: body})

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -597,6 +597,53 @@ defmodule Algolia do
   end
 
   @doc """
+  Search for query rules of a index matching a query
+
+  Allowed parameters:
+
+  * `query` Required
+  * `page`
+  * `hitsPerPage`
+  """
+  def search_rules(index, query, opts \\ []) do
+    body =
+      opts
+      |> Enum.into(%{})
+      |> Map.put("query", query)
+      |> Map.put("page", opts[:page] || 0)
+      |> Map.put("hitsPerPage", opts[:hits_per_page] || 20)
+      |> Map.drop([:page, :hits_per_page])
+      |> Jason.encode!()
+
+    :write
+    |> send_request(%{method: :post, path: Paths.search_rules(index), body: body})
+    |> inject_index_into_response(index)
+  end
+
+  @doc """
+  Get all the query rules of a index.
+
+  Only the index is required
+  """
+  def export_rules(index) do
+    get_all_paginated_hits(index, &search_rules/3)
+  end
+
+  @doc """
+  Create or update an list of synonyms.
+
+  Allowed params:
+
+  """
+  def batch_rules(index, batch, opts \\ []) do
+    body = Jason.encode!(batch)
+
+    :write
+    |> send_request(%{method: :post, path: Paths.batch_rules(index, opts), body: body})
+    |> inject_index_into_response(index)
+  end
+
+  @doc """
   Moves an index to new one
   """
   def move_index(src_index, dst_index) do

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -41,7 +41,7 @@ defmodule Algolia.Paths do
 
   def delete_by(index), do: index(index) <> "/deleteByQuery"
 
-  def settings(index), do: index(index) <> "/settings"
+  def settings(index, opts \\ []), do: index(index) <> "/settings" <> to_query(opts)
 
   def synonyms(index), do: index(index) <> "/synonyms"
 

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -48,8 +48,7 @@ defmodule Algolia.Paths do
   def search_synonyms(index), do: synonyms(index) <> "/search"
 
   def batch_synonyms(index, opts \\ []) do
-    params = Keyword.take(opts, [:forward_to_replicas, :replace_existing_synonyms])
-    synonyms(index) <> "/batch" <> to_query(params)
+    synonyms(index) <> "/batch" <> to_query(opts)
   end
 
   def rules(index), do: index(index) <> "/rules"
@@ -57,13 +56,11 @@ defmodule Algolia.Paths do
   def search_rules(index), do: rules(index) <> "/search"
 
   def batch_rules(index, opts \\ []) do
-    params = Keyword.take(opts, [:forward_to_replicas, :clearExistingRules])
-    rules(index) <> "/batch" <> to_query(params)
+    rules(index) <> "/batch" <> to_query(opts)
   end
 
-  def logs(opts) do
-    params = Keyword.take(opts, [:indexName, :offset, :length, :type])
-    "/#{@version}/logs" <> to_query(params)
+  def logs(opts \\ []) do
+    "/#{@version}/logs" <> to_query(opts)
   end
 
   defp to_query([]), do: ""

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -57,7 +57,7 @@ defmodule Algolia.Paths do
   def search_rules(index), do: rules(index) <> "/search"
 
   def batch_rules(index, opts \\ []) do
-    params = Keyword.take(opts, [:forward_to_replicas, :replace_existing_synonyms])
+    params = Keyword.take(opts, [:forward_to_replicas, :clearExistingRules])
     rules(index) <> "/batch" <> to_query(params)
   end
 

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -52,6 +52,15 @@ defmodule Algolia.Paths do
     synonyms(index) <> "/batch" <> to_query(params)
   end
 
+  def rules(index), do: index(index) <> "/rules"
+
+  def search_rules(index), do: rules(index) <> "/search"
+
+  def batch_rules(index, opts \\ []) do
+    params = Keyword.take(opts, [:forward_to_replicas, :replace_existing_synonyms])
+    rules(index) <> "/batch" <> to_query(params)
+  end
+
   def logs(opts) do
     params = Keyword.take(opts, [:indexName, :offset, :length, :type])
     "/#{@version}/logs" <> to_query(params)

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -43,6 +43,15 @@ defmodule Algolia.Paths do
 
   def settings(index), do: index(index) <> "/settings"
 
+  def synonyms(index), do: index(index) <> "/synonyms"
+
+  def search_synonyms(index), do: synonyms(index) <> "/search"
+
+  def batch_synonyms(index, opts \\ []) do
+    params = Keyword.take(opts, [:forward_to_replicas, :replace_existing_synonyms])
+    synonyms(index) <> "/batch" <> to_query(params)
+  end
+
   def logs(opts) do
     params = Keyword.take(opts, [:indexName, :offset, :length, :type])
     "/#{@version}/logs" <> to_query(params)

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -402,4 +402,68 @@ defmodule AlgoliaTest do
       assert synonym["input"] == hit["input"]
     end
   end
+
+  test "create or update rules" do
+    rules = [
+      %{
+        "condition" => %{
+          "anchoring" => "contains",
+          "pattern" => "name"
+        },
+        "consequence" => %{
+          "params" => %{
+            "query" => %{
+              "edits" => [
+                %{
+                  "delete" => "name",
+                  "type" => "remove"
+                }
+              ]
+            }
+          }
+        },
+        "description" => "",
+        "objectID" => "1550012768674"
+      },
+      %{
+        "condition" => %{
+          "anchoring" => "contains",
+          "pattern" => "yellow"
+        },
+        "consequence" => %{
+          "params" => %{
+            "query" => %{
+              "edits" => [
+                %{
+                  "type" => "replace",
+                  "delete" => "yellow",
+                  "insert" => "blue"
+                }
+              ]
+            }
+          }
+        },
+        "description" => "",
+        "enabled" => true,
+        "objectID" => "1548387674495"
+      }
+    ]
+
+    {:ok, _} =
+      @settings_test_index
+      |> batch_rules(rules, replace_existing_synonyms: true)
+      |> wait()
+
+    hits = @settings_test_index |> export_rules() |> Enum.map(& &1)
+
+    for {:ok, hit} <- hits do
+      query_rule = Enum.find(rules, &(&1["objectID"] == hit["objectID"]))
+
+      assert query_rule["condition"] == hit["condition"]
+      assert query_rule["consequence"] == hit["consequence"]
+      assert query_rule["description"] == hit["description"]
+      assert query_rule["enabled"] == hit["enabled"]
+      assert query_rule["objectID"] == hit["objectID"]
+    end
+  end
 end


### PR DESCRIPTION
This PRs currently adds the support to read, search, create and update for synonyms and query rules.

It is based on the [Algolia Gem](https://github.com/algolia/algoliasearch-client-ruby) implementation and the [Algolia official documentation](https://www.algolia.com/doc/).

I would love to here your suggestions.

Ps: The query rule is a paid feature, and since I don't have a paid personal key I opened the PR in wip to run the test suite.

## Steps
- [x] Add support to export all the synonyms
- [x] Add support to save a batch of synonyms
- [x] Test both implementations
- [x] Add support to export all the query rules
- [x] Add support to save a batch of query rules
- [x] Test both implementations
- [ ] Add support to read a synonym(get by `objectID`)
- [ ] Add support to read a query rule(get by `objectID`)
- [ ] Add support to delete a synonym
- [ ] Add support to delete a query rule
