### PR TITLE
Update example doc delete_by call.

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -410,7 +410,7 @@ defmodule Algolia do
 
   ## Examples
 
-      iex> Algolia.delete_by("index", filters: ["score < 30"])
+      iex> Algolia.delete_by("index", filters: "score < 30")
       {:ok, %{"indexName" => "index", "taskId" => 42, "deletedAt" => "2018-10-30T15:33:13.556Z"}}
   """
   def delete_by(index, opts) when is_list(opts) do


### PR DESCRIPTION
Algolia returns an error for the current example.

> Unexpected token string(<attribtue>:<id>) expected end of filter at col x"

Using a string is what the Algolia API expects.

![example](https://user-images.githubusercontent.com/1443346/108271799-5c477f80-713f-11eb-9873-9e448630c5a1.png)