### PR TITLE
Fix delete_object with nil object_id

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -372,7 +372,8 @@ defmodule Algolia do
   """
   def delete_object(index, object_id, opts \\ [])
 
-  def delete_object(_index, "", _request_options) do
+  def delete_object(_index, object_id, _request_options)
+      when is_nil(object_id) or object_id == "" do
     {:error, %InvalidObjectIDError{}}
   end
 

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -251,6 +251,10 @@ defmodule AlgoliaTest do
     assert {:error, %Algolia.InvalidObjectIDError{}} = delete_object("test", "")
   end
 
+  test "deleting an object with nil object_id should return an error" do
+    assert {:error, %Algolia.InvalidObjectIDError{}} = delete_object("test", nil)
+  end
+
   test "delete multiple objects" do
     objects = [%{id: "delete_multipel_objects_1"}, %{id: "delete_multipel_objects_2"}]
     {:ok, %{"objectIDs" => object_ids}} =


### PR DESCRIPTION
Today if you call `Algolia.delete_object("index_name", nil)` its delete the **entire index**.

this is because the delete index route is the same as delete object without the object id, see [algolia docs](https://www.algolia.com/doc/rest-api/search/#manage-indices-endpoints)
```elixir
DELETE /1/indexes/{indexName}/{objectID} # delete object path
DELETE /1/indexes/{indexName}/           # delete index path
```

so [Paths module](https://github.com/sikanhe/algolia-elixir/blob/master/lib/algolia/paths.ex#L24) builds the delete index path when object_id nil
```ex
iex(1)> Algolia.Paths.object("index", "1")
"/1/indexes/index/1"
iex(2)> Algolia.Paths.object("index", nil)
"/1/indexes/index/"
```